### PR TITLE
fix(nvidia): Add nvidia-container-module back

### DIFF
--- a/files/scripts/installnvidiakmod.sh
+++ b/files/scripts/installnvidiakmod.sh
@@ -55,9 +55,6 @@ modinfo -l /usr/lib/modules/${KERNEL_VERSION}/extra/nvidia/nvidia{,-drm,-modeset
 
 ./signmodules.sh "nvidia"
 
-rm -f /etc/yum.repos.d/negativo17-fedora-nvidia.repo
+dnf -y remove akmod-nvidia akmods kernel-devel kernel-headers
 
-systemctl disable akmods-keygen@akmods-keygen.service
-systemctl mask akmods-keygen@akmods-keygen.service
-systemctl disable akmods-keygen.target
-systemctl mask akmods-keygen.target
+rm -f /etc/yum.repos.d/negativo17-fedora-nvidia.repo

--- a/files/scripts/installnvidiapackages.sh
+++ b/files/scripts/installnvidiapackages.sh
@@ -14,11 +14,7 @@
 
 set -oue pipefail
 
-nvidia_packages_list=('nvidia-driver-cuda' 'libnvidia-fbc' 'libva-nvidia-driver' 'nvidia-driver' 'nvidia-modprobe' 'nvidia-persistenced' 'nvidia-settings' 'libnvidia-fbc' 'libva-nvidia-driver' 'nvidia-driver' 'nvidia-modprobe' 'nvidia-persistenced' 'nvidia-settings')
-
-if [[ "$OS_VERSION" != "43" ]]; then
-    nvidia_packages_list+=('nvidia-container-toolkit')
-fi
+nvidia_packages_list=('nvidia-driver-cuda' 'libnvidia-fbc' 'libva-nvidia-driver' 'nvidia-driver' 'nvidia-modprobe' 'nvidia-persistenced' 'nvidia-settings' 'libnvidia-fbc' 'libva-nvidia-driver' 'nvidia-driver' 'nvidia-modprobe' 'nvidia-persistenced' 'nvidia-settings' 'nvidia-container-toolkit')
 
 curl -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
     -o /etc/yum.repos.d/nvidia-container-toolkit.repo


### PR DESCRIPTION
Based on [this PR from universal blue](https://github.com/ublue-os/main/pull/1787), it looks like the `nvidia-container-module` can be added back again.
Also, I was comparing the base nvidia image from here and another one generated using the akmods module and I noticed a couple of packages that shouldn't be needed anymore after the kmod is built and installed. Namely: `akmod-nvidia`, `akmods`, `kernel-devel`, and `kernel-headers`, which should save some extra space.