### PR TITLE
Fix build error for gts images related to 7zip and appimage-thumbnailer

### DIFF
--- a/files/scripts/install-appimage-thumbnailer.sh
+++ b/files/scripts/install-appimage-thumbnailer.sh
@@ -7,7 +7,12 @@ if [ "$OS_ARCH" = "x86_64" ]; then
   release_assets=$(echo "$github_json" | jq -cr '.assets | map({(.name | tostring): .browser_download_url}) | add')
   rpm_url=$(echo "$release_assets" | jq -cr '.[keys_unsorted[] | select(test("appimage-thumbnailer.*x86_64\\.rpm$"))]')
   curl -fLsS --retry 5 -o "/tmp/appimage-thumbnailer.rpm" "$rpm_url"
-  dnf -y install "/tmp/appimage-thumbnailer.rpm" 7zip glib2 gdk-pixbuf2 librsvg2 cairo
+  if [ "$OS_VERSION" -lt 43 ]; then
+    dnf -y install p7zip
+  else
+    dnf -y install 7zip
+  fi
+  dnf -y install "/tmp/appimage-thumbnailer.rpm" glib2 gdk-pixbuf2 librsvg2 cairo
   rm -f "/tmp/appimage-thumbnailer.rpm"
 else
   echo "AppImage thumbnailer is not available for 'aarch64' and other architectures yet"


### PR DESCRIPTION
`7zip` replaces `p7zip`, but it's only built since F43. For older Fedora versions, install now deprecated `p7zip`.