### PR TITLE
fix: Use appropriate switches for flatpak update services

### DIFF
--- a/files/base/usr/lib/systemd/system/flatpak-system-updates.service
+++ b/files/base/usr/lib/systemd/system/flatpak-system-updates.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
-ExecStart=/usr/bin/sh -c '/usr/bin/flatpak --user uninstall --unused -y --noninteractive ; /usr/bin/flatpak --user update -y --noninteractive'
+ExecStart=/usr/bin/sh -c '/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive'
 RestartSec=1h
 Restart=on-failure
 

--- a/files/base/usr/lib/systemd/user/flatpak-user-updates.service
+++ b/files/base/usr/lib/systemd/user/flatpak-user-updates.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 ExecCondition=/bin/bash -c '[[ "$(busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Metered | cut -c 3-)" == @(2|4) ]]'
-ExecStart=/usr/bin/sh -c '/usr/bin/flatpak --system uninstall --unused -y --noninteractive ; /usr/bin/flatpak --system update -y --noninteractive'
+ExecStart=/usr/bin/sh -c '/usr/bin/flatpak --user uninstall --unused -y --noninteractive ; /usr/bin/flatpak --user update -y --noninteractive'
 RestartSec=1h
 Restart=on-failure
 


### PR DESCRIPTION
Currently the flatpak update user service is trying to update `--system` and the flatpak system service is trying to update `--user` packages which is causing the user service to fail due to lack of permissions and system packages to never get auto updated. This fix simply flips the switches between the two.